### PR TITLE
fix(json): remove `pinned` from serialized Capacity objects (#3993)

### DIFF
--- a/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/support/Capacity.java
+++ b/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/support/Capacity.java
@@ -1,5 +1,6 @@
 package com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.support;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.google.common.collect.ImmutableMap;
 import java.util.Map;
 import javax.annotation.Nonnegative;
@@ -17,6 +18,7 @@ public class Capacity {
    * @return true if the capacity of this server group is fixed, i.e min, max and desired are all
    *     the same
    */
+  @JsonIgnore
   public boolean isPinned() {
     return (max == desired) && (desired == min);
   }

--- a/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/utils/TrafficGuardSpec.groovy
+++ b/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/utils/TrafficGuardSpec.groovy
@@ -16,10 +16,12 @@
 
 package com.netflix.spinnaker.orca.clouddriver.utils
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spectator.api.NoopRegistry
 import com.netflix.spectator.api.Registry
 import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService
 import com.netflix.spinnaker.moniker.Moniker
+import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.support.Capacity
 import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.support.Location
 import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.support.Location.Type
 import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.support.TargetServerGroup
@@ -66,6 +68,14 @@ class TrafficGuardSpec extends Specification {
         instances: [[healthState: 'Up']] * up + [[healthState: 'OutOfService']] * down,
         capacity: [min: 0, max: 4, desired: 3]
     ] + overrides
+  }
+
+  def "pinned should not appear in serialized capacity"() {
+    def mapper = new ObjectMapper()
+    def capacity = new Capacity(1, 1, 1)
+
+    expect:
+    !mapper.writeValueAsString(capacity).contains('pinned')
   }
 
   void "should ignore disabled traffic guards"() {


### PR DESCRIPTION
* fix(json): remove `pinned` from serialized Capacity objects

It was meant as a helper function, but actually becomes a field in serialized server groups. It can make its way to deck and be confusing to users.

* fixup! fix(json): remove `pinned` from serialized Capacity objects

We prefer small, well tested pull requests.

Please refer to [Contributing to Spinnaker](https://spinnaker.io/community/contributing/).

When filling out a pull request, please consider the following:

* Follow the commit message conventions [found here](https://spinnaker.io/community/contributing/submitting/).
* Provide a descriptive summary for your changes.
* If it fixes a bug or resolves a feature request, be sure to link to that issue.
* Add inline code comments to changes that might not be obvious.
* Squash your commits as you keep adding changes.
* Add a comment to @spinnaker/reviewers for review if your issue has been outstanding for more than 3 days.

Note that we are unlikely to accept pull requests that add features without prior discussion. The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.
